### PR TITLE
PITFALLS: confusing into-system compiler errors

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Common Pitfalls](./pitfalls/_index.md)
   - [Slow Performance](./pitfalls/performance.md)
   - [File Format Support](./pitfalls/file-formats.md)
+  - [Error adding function as system](./pitfalls/into-system.md)
   - [Bevy Time vs. Rust/OS time](./pitfalls/time.md)
   - [UI layout is inverted](./pitfalls/ui-y-up.md)
 

--- a/src/basics/systems.md
+++ b/src/basics/systems.md
@@ -4,15 +4,13 @@ Systems are functions you write, which are run by Bevy.
 
 This is where you implement all your game logic.
 
-These functions can only take special parameter types, to specify what game data you want to access.
+These functions can only take special parameter types, to specify what game data you want to access. [If you use unsupported types in your function, you will get confusing compiler errors!](../pitfalls/into-system.md)
 
 ```rust,no_run,noplayground
 {{#include ../code_bevy_release/src/basics.rs:sys-debug-res}}
 ```
 
-System parameters can be grouped into tuples. This is useful for organization,
-or to overcome the limits on the maximum number of parameters (if you get a
-compiler error after adding more parameters to your system):
+System parameters can be grouped into tuples. This is useful for organization.
 
 ```rust,no_run,noplayground
 {{#include ../code_bevy_release/src/basics.rs:sys-param-tuple}}

--- a/src/cheatsheet/master.md
+++ b/src/cheatsheet/master.md
@@ -12,6 +12,10 @@ Click on "[explain]" links to go to the relevant [Bevy Basics](../basics/_index.
 
 [[explain](../basics/systems.md)]
 
+Regular Rust functions, but can only take special parameter types supported by Bevy:
+
+{{#include ../include/systemparams-master.md}}
+
 ## Entities and Components
 
 [[explain](../basics/ec.md)]

--- a/src/cheatsheet/release.md
+++ b/src/cheatsheet/release.md
@@ -12,6 +12,10 @@ Click on "[explain]" links to go to the relevant [Bevy Basics](../basics/_index.
 
 [[explain](../basics/systems.md)]
 
+Regular Rust functions, but can only take special parameter types supported by Bevy:
+
+{{#include ../include/systemparams-release.md}}
+
 ## Entities and Components
 
 [[explain](../basics/ec.md)]

--- a/src/include/systemparams-master.md
+++ b/src/include/systemparams-master.md
@@ -1,0 +1,14 @@
+ - `&mut Commands`
+ - `Res<T>` / `ResMut<T>`
+ - `Local<T>`
+ - `EventReader<T>`
+ - `Query<T, F = ()>`; `T` can be a tuple of up to 16 types
+ - `QuerySet` with up to 4 queries
+ - `NonSend<T>`
+ - `ChangedRes<T>`
+ - `Arc<parking_lot::Mutex<Commands>>`
+ - `Or<(...)>` (use with `ChangedRes`), with up to 16 members
+ - tuples containing any of the above, with up to 16 members
+ - `DrawContext` (advanced usage, for rendering)
+ 
+Your function can have a maximum of 16 total parameters.

--- a/src/include/systemparams-release.md
+++ b/src/include/systemparams-release.md
@@ -1,0 +1,12 @@
+ - `&mut Commands`
+ - `Res<T>` / `ResMut<T>`
+ - `Local<T>`
+ - `Query<T, F = ()>`; `T` can be a tuple of up to 16 types
+ - `QuerySet` with up to 4 queries
+ - `ChangedRes<T>`
+ - `Arc<parking_lot::Mutex<Commands>>`
+ - `Or<(...)>` (use with `ChangedRes`), with up to 16 members
+ - tuples containing any of the above, with up to 16 members
+ - `DrawContext` (advanced usage, for rendering)
+ 
+Your function can have a maximum of 16 total parameters.

--- a/src/pitfalls/into-system.md
+++ b/src/pitfalls/into-system.md
@@ -1,0 +1,50 @@
+# Error adding function as system
+
+You can sometimes get confusing arcane compiler errors when you try to add
+systems to your Bevy app.
+
+The errors can look like this:
+
+```
+no method named `system` found for fn item `for<'r, 's> fn(bevy::prelude::Query<'r, &'s Component>, bevy::prelude::Commands) {my_system}` in the current scope
+`my_system` is a function, perhaps you wish to call it
+```
+
+This is caused by your function having incompatible parameters. Bevy can only
+accept special types as system parameters.
+
+You might also get an error that looks like this:
+
+```
+the trait bound `Component: WorldQuery` is not satisfied
+the trait `WorldQuery` is not implemented for `Component`
+```
+
+This is caused by a malformed query, such as if you write `Query<Component>` instead of `Query<&Component>` or `Query<&mut Component>`.
+
+## Common beginner mistakes
+
+1. Using `Commands` instead of `&mut Commands`.
+2. Using `Query<MyStuff>` instead of `Query<&MyStuff>` or `Query<&mut MyStuff>`.
+3. Using your resource types directly without `Res` or `ResMut`.
+4. Using your component types directly without putting them in a `Query`.
+5. Using other arbitrary types in your function.
+
+Note that `Query<Entity>` is correct, because the Entity ID is special; it is not a component.
+
+## Supported types (bevy 0.4)
+
+It can be difficult to figure out what types are supported from the [API
+docs](https://docs.rs/bevy/0.4.0/bevy/ecs/trait.FetchSystemParam.html), so I
+will give you a nice summary here on this page.
+
+Only the following types are supported as system parameters:
+
+{{#include ../include/systemparams-release.md}}
+
+You can nest tuples as much as you want, to avoid running into the limits on the
+maximum numbers of parameters, or simply to organize your parameters into groups.
+
+## Supported types (bevy git)
+
+{{#include ../include/systemparams-master.md}}


### PR DESCRIPTION
Closes #16 .

New pitfalls page offers a comprehensive coverage of the common beginner mistakes, compiler errors, and system parameter types supported by bevy.

The list of supported system parameter types is also included into the Cheatsheets.

The Systems page in Bevy Basics links to the pitfalls page, to help users find it.