### PR TITLE
Create redirections

### DIFF
--- a/src/basics/_index.html
+++ b/src/basics/_index.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/_index.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/_index.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/_index.html">https://bevy-cheatbook.github.io/programming/_index.html</a>
+</h1>
+</body>
+</html>

--- a/src/basics/app-builder.html
+++ b/src/basics/app-builder.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/app-builder.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/app-builder.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/app-builder.html">https://bevy-cheatbook.github.io/programming/app-builder.html</a>
+</h1>
+</body>
+</html>

--- a/src/basics/parent-child.html
+++ b/src/basics/parent-child.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/parent-child.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/parent-child.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/parent-child.html">https://bevy-cheatbook.github.io/programming/parent-child.html</a>
+</h1>
+</body>
+</html>

--- a/src/basics/plugins.html
+++ b/src/basics/plugins.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/plugins.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/plugins.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/plugins.html">https://bevy-cheatbook.github.io/programming/plugins.html</a>
+</h1>
+</body>
+</html>

--- a/src/basics/queries.html
+++ b/src/basics/queries.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/queries.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/queries.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/queries.html">https://bevy-cheatbook.github.io/programming/queries.html</a>
+</h1>
+</body>
+</html>

--- a/src/basics/stages.html
+++ b/src/basics/stages.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/stages.html" />
+    <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/stages.html" />
+</head>
+<body>
+<h1>
+    The page been moved to <a href="https://bevy-cheatbook.github.io/programming/stages.html">https://bevy-cheatbook.github.io/programming/stages.html</a>
+</h1>
+</body>
+</html>

--- a/src/cheatsheet/release.html
+++ b/src/cheatsheet/release.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/cheatsheet.html" />
+  <link rel="canonical" href="https://bevy-cheatbook.github.io/cheatsheet.html" />
+</head>
+<body>
+<h1>
+  The page been moved to <a href="https://bevy-cheatbook.github.io/cheatsheet.html">https://bevy-cheatbook.github.io/cheatsheet.html</a>
+</h1>
+</body>
+</html>

--- a/src/features/assets.md
+++ b/src/features/assets.md
@@ -44,7 +44,7 @@ things into your game, such as 2D sprites, 3D models, or UI, their respective
 components will need handles for the assets they use.
 
 You could store your handles somewhere that is convenient for you (such as in
-[resources](../basics/res.md)).
+[resources](../programming/res.md)).
 
 If you don't have your handle stored anywhere, you can always generate one from
 a path by calling `asset_server.load`. You could simply do that whenever you

--- a/src/features/transforms.md
+++ b/src/features/transforms.md
@@ -37,15 +37,15 @@ where the Y axis points down.
 
 ## Bevy's Transforms
 
-In Bevy, transforms are represented by *two* [components](../basics/ec.md):
-`Transform` and `GlobalTransform`. Any [Entity](../basics/ecs-intro.md) that
+In Bevy, transforms are represented by *two* [components](../programming/ec.md):
+`Transform` and `GlobalTransform`. Any [Entity](../programming/ecs-intro.md) that
 represents an object in the game world needs to have both.
 
 `Transform` is what you typically work with. It is a `struct` containing the
 translation, rotation, and scale. To read or manipulate these values, access
-them from your [systems](../basics/systems.md) using a [query](../basics/queries.md).
+them from your [systems](../programming/systems.md) using a [query](../programming/queries.md).
 
-If the entity has a [parent](../basics/parent-child.md), the `Transform`
+If the entity has a [parent](../programming/parent-child.md), the `Transform`
 component is relative to the parent. This means that the child object will
 move/rotate/scale along with the parent.
 

--- a/src/next/index.html
+++ b/src/next/index.html
@@ -1,0 +1,16 @@
+---
+layout: null
+---
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/programming/_next-steps.html" />
+  <link rel="canonical" href="https://bevy-cheatbook.github.io/programming/_next-steps.html" />
+</head>
+<body>
+<h1>
+  The page been moved to <a href="https://bevy-cheatbook.github.io/programming/_next-steps.html">https://bevy-cheatbook.github.io/programming/_next-steps.html</a>
+</h1>
+</body>
+</html>


### PR DESCRIPTION
Ok so here is how it works to fix #58 

#### Step 1: redirect the users
Basically for those who will land on the old page referred by Google, the replacing page that I've created will be load, but the browser will redirect the user to the new page, due to the presence of this line:

```html
<meta http-equiv="refresh" content="0;url=https://bevy-cheatbook.github.io/cheatsheet.html" />
```

#### Step 2: let the search engine know we moved the page
Because of this line, when the Google bot will come back to refresh the content of the cheatbook, we let him know that we moved the page:
```html
<link rel="canonical" href="https://bevy-cheatbook.github.io/cheatsheet.html" />
```
Google will change the old page link to the canonical URL in its page index (or remove the bad link if the new page is already registered into its index).
In few days or weeks (totally random, it only depends on Google), the files I've created won't be needed anymore. To know that Google has registered the redirection.

I'll regularly make the verification and I'll make a PR to delete those files when they won't be needed anymore.

_____
I don't use Jekyll so often so this may need a local test before running on production.
It won't break anything since it's related to pages that are not linked anymore into the cheatbook but it may need some fine tuning to make it work perfectly.

Also I'm not sure about the /cheatsheet/release.html redirecting to /cheatsheet.html > I understood that the old cheatsheet were "simplified" so maybe this page does not exists anymore.

Same for the /next/ page, not sure of what it actually were? /_next-steps.html page was the more accurate I've found.

