### PR TITLE
Fix assets-ready.rs example

### DIFF
--- a/src/code/examples/assets-ready.rs
+++ b/src/code/examples/assets-ready.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+#[derive(Default)]
 // ANCHOR: example
 struct AssetsLoading(Vec<HandleUntyped>);
 
@@ -49,6 +50,7 @@ fn check_assets_ready(
 fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
+        .init_resource::<AssetsLoading>()
         .add_startup_system(setup.system())
         .add_system(check_assets_ready.system())
         .run();


### PR DESCRIPTION
The example doesn't initialize the `AssetsLoading` resource, causing:

    'Requested resource does not exist: playground::AssetsLoading', /path/to/system_param.rs:394:17

This type of change should likely be added to the other examples.

The change respects the current structure of not showing the strictly necessary code (ie. no `Default` attribute, and no `main()` function).