### PR TITLE
Correct .ogg feature name

### DIFF
--- a/src/pitfalls/file-formats.md
+++ b/src/pitfalls/file-formats.md
@@ -11,5 +11,5 @@ You can enable more formats with cargo features:
 ```toml
 [dependencies.bevy]
 version = "0.4"
-features = ["jpeg", "tga", "bmp", "dds", "flac", "ogg", "wav"]
+features = ["jpeg", "tga", "bmp", "dds", "flac", "vorbis", "wav"]
 ```


### PR DESCRIPTION
- ~~Proposing an easier way of getting the asset loading state for a collection of handles~~
- Fix feature name to enable loading `.ogg` files as assets (see [bevy cargo file](https://github.com/bevyengine/bevy/blob/main/Cargo.toml#L66))