### PR TITLE
fix: use proper feature for `getrandom` for wasm target

### DIFF
--- a/src/platforms/wasm/rng.md
+++ b/src/platforms/wasm/rng.md
@@ -14,7 +14,7 @@ To use random numbers in your project, add this to your dependencies in
 ```toml
 [dependencies]
 rand = "0.8"
-getrandom = { version = "0.2", features = ["wasm-bindgen"] }
+getrandom = { version = "0.2", features = ["js"] }
 ```
 
 Note that you must ensure that all the versions are compatible. `getrandom`


### PR DESCRIPTION
it seems like there had been a "wasm-bindgen" feature in getrandom@0.1, but it's gone in @0.2. anyway... [the required feature in this case is `js`](https://docs.rs/getrandom/0.2.3/getrandom/#webassembly-support)