### PR TITLE
Change to config.toml, as this changed in rust 1.39

### DIFF
--- a/src/pitfalls/performance.md
+++ b/src/pitfalls/performance.md
@@ -23,7 +23,7 @@ However, fully-optimized release builds can be slow to compile.
 Solutions:
 
 ```toml
-# in `Cargo.toml` or `.cargo/config`
+# in `Cargo.toml` or `.cargo/config.toml`
 
 # Enable optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]


### PR DESCRIPTION
In rust 1.39 this was changed to `.toml`, see the note here: https://doc.rust-lang.org/cargo/reference/config.html

The getting started with bevy guide also recommends changing this file - https://bevyengine.org/learn/book/getting-started/setup/

Tripped me up for a second as I also use to use config ages ago, and getting back into rust was a bit confused until I saw the footnote on the documentation page.