### PR TITLE
Add extra CLI command that maxes out all optimizations

### DIFF
--- a/src/platforms/wasm/size-opt.md
+++ b/src/platforms/wasm/size-opt.md
@@ -78,6 +78,9 @@ wasm-opt -Oz -o output.wasm input.wasm
 
 # Optimize aggressively for speed.
 wasm-opt -O3 -o output.wasm input.wasm
+
+# Optimize aggressively for both size and speed.
+wasm-opt -O -ol 100 -s 100 -o output.wasm input.wasm
 ```
 
 ## Use the `wee-alloc` memory allocator


### PR DESCRIPTION
In my testing, `-Oz` and `-O -ol 100 -s 100` only differed by a few dozen thousand bytes (in a 6MiB binary) which seems worth it.