### PR TITLE
handle orthographic scale in cursor2world

### DIFF
--- a/src/code/examples/cursor2world.rs
+++ b/src/code/examples/cursor2world.rs
@@ -38,7 +38,7 @@ fn my_cursor_system(
         }
 
         // undo orthographic scale and apply the camera transform
-        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(1.0 / scale);
+        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(scale);
         eprintln!("World coords: {}/{}", pos_wld.x, pos_wld.y);
     }
 }

--- a/src/code/examples/cursor2world.rs
+++ b/src/code/examples/cursor2world.rs
@@ -15,7 +15,7 @@ fn my_cursor_system(
     // need to get window dimensions
     wnds: Res<Windows>,
     // query to get camera transform
-    q_camera: Query<(&Transform, &OrthographicProjection), With<MainCamera>>
+    q_camera: Query<(&Transform, Option<&OrthographicProjection>), With<MainCamera>>
 ) {
     // get the primary window
     let wnd = wnds.get_primary().unwrap();
@@ -32,8 +32,13 @@ fn my_cursor_system(
         // assuming there is exactly one main camera entity, so this is OK
         let (camera_transform, ortho_projection) = q_camera.single();
 
+        let mut scale = 1.0;
+        if let Some(ortho_projection) = ortho_projection {
+            scale /= ortho_projection.scale;
+        }
+
         // undo orthographic scale and apply the camera transform
-        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(1.0 / ortho_projection.scale);
+        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(1.0 / scale);
         eprintln!("World coords: {}/{}", pos_wld.x, pos_wld.y);
     }
 }

--- a/src/code/examples/cursor2world.rs
+++ b/src/code/examples/cursor2world.rs
@@ -15,7 +15,7 @@ fn my_cursor_system(
     // need to get window dimensions
     wnds: Res<Windows>,
     // query to get camera transform
-    q_camera: Query<&Transform, With<MainCamera>>
+    q_camera: Query<(&Transform, &OrthographicProjection), With<MainCamera>>
 ) {
     // get the primary window
     let wnd = wnds.get_primary().unwrap();
@@ -30,10 +30,10 @@ fn my_cursor_system(
         let p = pos - size / 2.0;
 
         // assuming there is exactly one main camera entity, so this is OK
-        let camera_transform = q_camera.single();
+        let (camera_transform, ortho_projection) = q_camera.single();
 
-        // apply the camera transform
-        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(1.0);
+        // undo orthographic scale and apply the camera transform
+        let pos_wld = camera_transform.compute_matrix() * p.extend(0.0).extend(1.0 / ortho_projection.scale);
         eprintln!("World coords: {}/{}", pos_wld.x, pos_wld.y);
     }
 }


### PR DESCRIPTION
this currently doesn't work correctly when an orthographic scale is applied. this pr fixes it by setting the `w` component of the `pos_wld` vector to `1. / ortho_scale`, undoing the scale before multiplying the input vector by the view matrix.