### PR TITLE
fix link to example code

### DIFF
--- a/src/cookbook/pan-orbit-camera.md
+++ b/src/cookbook/pan-orbit-camera.md
@@ -2,7 +2,7 @@
 
 {{#include ../include/links.md}}
 
-[Click here for the full example code.][cbexample::pan-orbit-camera.rs]
+[Click here for the full example code.][cbexample::pan-orbit-camera]
 
 ---
 


### PR DESCRIPTION
<a href="https://bevy-cheatbook.github.io/cookbook/pan-orbit-camera.html">page</a>

![image](https://user-images.githubusercontent.com/724844/164985448-b6e59b05-57e6-4e13-8b49-57b1a5a2f347.png)