### PR TITLE
Labels chapter: Add missing required PartialEq trait

### DIFF
--- a/src/include/links/docsrs.md
+++ b/src/include/links/docsrs.md
@@ -196,6 +196,7 @@
 [std::Hash]: https://doc.rust-lang.org/stable/std/hash/trait.Hash.html
 [std::Instant]: https://doc.rust-lang.org/stable/std/time/struct.Instant.html
 [std::Option]: https://doc.rust-lang.org/stable/std/option/enum.Option.html
+[std::PartialEq]: https://doc.rust-lang.org/stable/std/cmp/trait.PartialEq.html
 [std::Rc]: https://doc.rust-lang.org/stable/std/rc/struct.Rc.html
 [std::Result]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
 [std::Send]: https://doc.rust-lang.org/stable/std/marker/trait.Send.html

--- a/src/programming/labels.md
+++ b/src/programming/labels.md
@@ -21,9 +21,9 @@ You need to derive the appropriate trait, depending on what they will be
 used for: `StageLabel`, `SystemLabel`, `RunCriteriaLabel`, or `AmbiguitySetLabel`.
 
 Any Rust type is suitable, as long as it has the following standard Rust
-traits: [`Clone`][std::Clone] + [`Eq`][std::Eq] + [`Hash`][std::Hash]
-+ [`Debug`][std::Debug] (and the implied [`Send`][std::Send] +
-[`Sync`][std::Sync] + `'static`).
+traits: [`Clone`][std::Clone] + [`PartialEq`][std::PartialEq] + [`Eq`][std::Eq] +
+[`Hash`][std::Hash] + [`Debug`][std::Debug] (and the implied [`Send`][std::Send]
++ [`Sync`][std::Sync] + `'static`).
 
 ```rust,no_run,noplayground
 {{#include ../code/src/basics.rs:labels}}


### PR DESCRIPTION
PartialEq is a required trait for labels, and it's missing in the description. It's a minor correction, but it's a confusing to have the description not matching the examples 🙂

Thanks for your work 🙂