### PR TITLE
Fix event example link

### DIFF
--- a/src/programming/events.md
+++ b/src/programming/events.md
@@ -3,7 +3,7 @@
 {{#include ../include/links.md}}
 
 Relevant official examples:
-[`event`][cb::event].
+[`event`][example::event].
 
 ---
 


### PR DESCRIPTION
A tiny fix to the official example link for events.