### PR TITLE
fix the camera query in pan-orbit-camera example

### DIFF
--- a/src/code/examples/pan-orbit-camera.rs
+++ b/src/code/examples/pan-orbit-camera.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy::input::mouse::{MouseWheel,MouseMotion};
-use bevy::render::camera::PerspectiveProjection;
+use bevy::render::camera::Projection;
 
 // ANCHOR: example
 /// Tags an entity as capable of panning and orbiting.
@@ -28,7 +28,7 @@ fn pan_orbit_camera(
     mut ev_motion: EventReader<MouseMotion>,
     mut ev_scroll: EventReader<MouseWheel>,
     input_mouse: Res<Input<MouseButton>>,
-    mut query: Query<(&mut PanOrbitCamera, &mut Transform, &PerspectiveProjection)>,
+    mut query: Query<(&mut PanOrbitCamera, &mut Transform, &Projection)>,
 ) {
     // change input mapping for orbit and panning here
     let orbit_button = MouseButton::Right;
@@ -81,7 +81,9 @@ fn pan_orbit_camera(
             any = true;
             // make panning distance independent of resolution and FOV,
             let window = get_primary_window_size(&windows);
-            pan *= Vec2::new(projection.fov * projection.aspect_ratio, projection.fov) / window;
+            if let Projection::Perspective(projection) = projection {
+                pan *= Vec2::new(projection.fov * projection.aspect_ratio, projection.fov) / window;
+            }
             // translate by local axes
             let right = transform.rotation * Vec3::X * -pan.x;
             let up = transform.rotation * Vec3::Y * pan.y;


### PR DESCRIPTION
The `pan-orbit-camera` example doesn't respond to mouse events after recent bevy 0.8 update, it turns out the camera query is not working.