### PR TITLE
Fix wasm-bindgen command

### DIFF
--- a/src/platforms/wasm.md
+++ b/src/platforms/wasm.md
@@ -84,7 +84,7 @@ Run:
 
 ```sh
 cargo build --release --target wasm32-unknown-unknown
-wasm-bindgen --out-dir ./out/ --target web ./target/
+wasm-bindgen --out-dir ./out/ --target web ./target/wasm32-unknown-unknown/release/{your-game-name}.wasm
 ```
 
 `./out/` is the directory where it will place the output files.


### PR DESCRIPTION
I tried to run `wasm-bindgen` by bellow command. 

```
wasm-bindgen --out-dir ./out/ --target web ./target/
```

But I can't run, because of below error.

```
...
   Compiling bevy_sprite v0.8.1
   Compiling bevy_pbr v0.8.1
   Compiling bevy_text v0.8.1
   Compiling bevy_gltf v0.8.1
   Compiling bevy_ui v0.8.1
   Compiling bevy_internal v0.8.1
   Compiling bevy v0.8.1
   Compiling mygame v0.1.0 (/Users/morimorikochan/rust/inkbomb)
    Finished release [optimized] target(s) in 1m 33s
error: failed reading './target/'

Caused by:
    Is a directory (os error 21)
```

According to [this](https://dev.to/sbelzile/making-games-in-rust-deploying-a-bevy-app-to-the-web-1ahn), It's command works.

```
wasm-bindgen --out-dir ./out/ --target web ./target/wasm32-unknown-unknown/release/mygame.wasm
```
