### PR TITLE
Fix warning in pan-orbit-camera

### DIFF
--- a/src/code/examples/pan-orbit-camera.rs
+++ b/src/code/examples/pan-orbit-camera.rs
@@ -39,13 +39,10 @@ fn pan_orbit_camera(
     let mut scroll = 0.0;
     let mut orbit_button_changed = false;
 
-    if input_mouse.pressed(orbit_button) {
-        for ev in ev_motion.iter() {
+    for ev in ev_motion.iter() {
+        if input_mouse.pressed(orbit_button) {
             rotation_move += ev.delta;
-        }
-    } else if input_mouse.pressed(pan_button) {
-        // Pan only if we're not rotating at the moment
-        for ev in ev_motion.iter() {
+        } else if input_mouse.pressed(pan_button) {
             pan += ev.delta;
         }
     }


### PR DESCRIPTION
Getting the warning below in Bevy 0.9
```
2023-01-05T22:50:16.707312Z  WARN bevy_ecs::event: Missed 213 `bevy_input::mouse::MouseMotion` events. Consider reading from the `EventReader` more often (generally the best solution) or calling Events::update() less frequently (normally this is called once per frame). This problem is most likely due to run criteria/fixed timesteps or consuming events conditionally. See the Events documentation for more information. 
```
Doing what is recommended