### PR TITLE
Add `WorlId` to list of built in Bevy system params

### DIFF
--- a/src/include/builtins.md
+++ b/src/include/builtins.md
@@ -359,6 +359,8 @@ In regular [systems][cb::system]:
    The name (string) of the system, may be useful for debugging
  - [`&World`][bevy::World]:
    Read-only [direct access to the ECS World][cb::world]
+ - [`WorldId`][bevy::WorldId]:
+   The ID of the world the system is currently running in
  - [`Entities`][bevy::Entities]:
    Low-level ECS metadata: All entities
  - [`Components`][bevy::Components]:


### PR DESCRIPTION
In 0.10 `WorldId` can now be used as a system parameter to get the ID of the world the system in running on