### PR TITLE
Updated states.md for Bevy v0.10

### DIFF
--- a/src/code010/src/basics.rs
+++ b/src/code010/src/basics.rs
@@ -1,0 +1,145 @@
+#[allow(dead_code)]
+#[allow(unused_imports)]
+mod app5 {
+    use bevy::prelude::*;
+    use super::*;
+
+// ANCHOR: check-state
+fn play_music(
+    app_state: Res<State<AppState>>,
+    // ...
+) {
+    match app_state.0 {
+        AppState::MainMenu => {
+            // TODO: play menu music
+        }
+        AppState::InGame => {
+            // TODO: play game music
+        }
+        AppState::Paused => {
+            // TODO: play pause screen music
+        }
+        AppState::SetupGame | AppState::CleanupGame => {
+            // no music to play, either setting up or cleaning up the game
+        }
+    }
+}
+// ANCHOR_END: check-state
+
+// ANCHOR: change-state
+fn enter_game(mut app_state: ResMut<NextState<AppState>>) {
+    app_state.set(AppState::InGame);
+}
+// ANCHOR_END: change-state
+
+// ANCHOR: state-input-clear
+fn esc_to_menu(
+    key: Res<Input<KeyCode>>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    if key.just_pressed(KeyCode::Escape) {
+        next_state.set(AppState::InGame)
+    }
+}
+// ANCHOR_END: state-input-clear
+
+// ANCHOR: app-states
+#[derive(States, PartialEq, Eq, Debug, Clone, Hash, Default)]
+enum AppState {
+    // one of the states must be the default
+    #[default]
+    MainMenu,
+    SetupGame,
+    InGame,
+    Paused,
+    CleanupGame,
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+
+        // add the app state type
+        .add_state::<AppState>()
+
+        // add systems to run regardless of state, as usual
+        .add_system(play_music)
+
+        // systems to run only in the main menu
+        .add_system(
+            handle_ui_buttons.in_set(OnUpdate(AppState::MainMenu))
+        )
+
+        // setup when entering the state
+        .add_system(
+            setup_menu.in_schedule(OnEnter(AppState::MainMenu))
+        )
+
+        // cleanup when exiting the state
+        .add_system(
+            close_menu.in_schedule(OnExit(AppState::MainMenu))
+        )
+        .run();
+}
+// ANCHOR_END: app-states
+
+fn animate_trees() {}
+fn animate_water() {}
+fn player_movement() {}
+fn player_idle() {}
+fn reset_player() {}
+fn hide_enemies() {}
+fn setup_player() {}
+fn despawn_player() {}
+fn setup_map() {}
+fn despawn_map() {}
+fn handle_ui_buttons() {}
+fn setup_menu() {}
+fn close_menu() {}
+
+fn main2() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // add the app state type
+        .add_state::<AppState>()
+// ANCHOR: app-states-complex
+        // player movement only when actively playing
+        .add_system(
+            player_movement
+                .in_set(OnUpdate(AppState::InGame))
+        )
+        // player idle animation while paused
+        .add_system(
+            player_idle
+                .in_set(OnUpdate(AppState::Paused))
+        )
+        // animations both while paused and while actively playing
+        .add_systems(
+            (animate_trees, animate_water)
+                .in_set(OnUpdate(AppState::InGame))
+                .in_set(OnUpdate(AppState::Paused))
+        )
+        // things to do when becoming paused
+        .add_system(
+            hide_enemies
+                .in_schedule(OnEnter(AppState::Paused))
+        )
+        // things to do when becoming active again
+        .add_system(
+            reset_player
+                .in_schedule(OnExit(AppState::Paused))
+        )
+        // setup when first entering the game from main menu
+        .add_systems(
+            (setup_player, setup_map)
+                .in_schedule(OnEnter(AppState::SetupGame))
+        )
+        // cleanup when exiting the game for good
+        .add_systems(
+            (despawn_player, despawn_map)
+                .in_schedule(OnEnter(AppState::CleanupGame))
+        )
+// ANCHOR_END: app-states-complex
+        .run();
+}
+}

--- a/src/include/links010/docsrs.md
+++ b/src/include/links010/docsrs.md
@@ -150,6 +150,7 @@
 [bevy::Sprite]: https://docs.rs/bevy/0.10.1/bevy/sprite/struct.Sprite.html
 [bevy::StandardMaterial]: https://docs.rs/bevy/0.10.1/bevy/pbr/struct.StandardMaterial.html
 [bevy::State]: https://docs.rs/bevy/0.10.1/bevy/ecs/schedule/struct.State.html
+[bevy::NextState]: https://docs.rs/bevy/0.10.1/bevy/ecs/schedule/struct.NextState.html
 [bevy::StaticSystemParam]: https://docs.rs/bevy/0.10.1/bevy/ecs/system/struct.StaticSystemParam.html
 [bevy::Stopwatch]: https://docs.rs/bevy/0.10.1/bevy/time/struct.Stopwatch.html
 [bevy::Style]: https://docs.rs/bevy/0.10.1/bevy/ui/struct.Style.html

--- a/src/programming/states.md
+++ b/src/programming/states.md
@@ -1,4 +1,4 @@
-{{#include ../include/header09.md}}
+{{#include ../include/header010.md}}
 
 # States
 
@@ -23,7 +23,7 @@ To use states, define an enum type and add [system sets][cb::systemset]
 to your [app builder][cb::app]:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:app-states}}
+{{#include ../code010/src/basics.rs:app-states}}
 ```
 
 It is OK to have multiple system sets for the same state.
@@ -34,6 +34,7 @@ system ordering][cb::system-order].
 This can also be useful with [Plugins][cb::plugin]. Each plugin can add
 its own set of systems to the same state.
 
+// TODO: Is this paragraph still true?
 States are implemented using [run criteria][cb::runcriteria] under the hood.
 These special system set constructors are really just helpers to automatically
 add the state management run criteria.
@@ -41,16 +42,17 @@ add the state management run criteria.
 ## Controlling States
 
 Inside of systems, you can check and control the state using the
-[`State<T>`][bevy::State] resource:
+[`State<T>`][bevy::State] and [`NextState<T>`][bevy::NextState]
+resources respectively:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:check-state}}
+{{#include ../code010/src/basics.rs:check-state}}
 ```
 
 To change to another state:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:change-state}}
+{{#include ../code010/src/basics.rs:change-state}}
 ```
 
 After the systems of the current state complete, Bevy will transition to
@@ -60,32 +62,14 @@ You can do arbitrarily many state transitions in a single frame update. Bevy
 will handle all of them and execute all the relevant systems (before moving
 on to the next [stage][cb::stage]).
 
-## State Stack
-
-Instead of completely transitioning from one state to another, you can also
-overlay states, forming a stack.
-
-This is how you can implement things like a "game paused" screen, or an
-overlay menu, with the game world still visible / running in the background.
-
-You can have some systems that are still running even when the state is
-"inactive" (that is, in the background, with other states running on top). You
-can also add one-shot systems to run when "pausing" or "resuming" the state.
-
-In your [app builder][cb::app]:
+Here is a more complex example of setting systems to run during particular
+states or state transitions in your [app builder][cb::app]:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:state-stack}}
+{{#include ../code/src/basics.rs:app-states-complex}}
 ```
 
-To manage states like this, use `push`/`pop`:
-
-```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:state-push-pop}}
-```
-
-(using `.set` as shown before replaces the active state at the top of the stack)
-
+// TODO: Is this section still true?
 ## Known Pitfalls and Limitations
 
 ### Combining with Other Run Criteria
@@ -120,7 +104,7 @@ If you want to use [`Input<T>`][bevy::Input] to trigger state transitions using
 a button/key press, you need to clear the input manually by calling `.reset`:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:state-input-clear}}
+{{#include ../code010/src/basics.rs:state-input-clear}}
 ```
 
 (note that this requires [`ResMut`][bevy::ResMut])


### PR DESCRIPTION
First PR for anything Bevy related so I'm sure there are some things to change in here. I left some TODOs in areas that I wasn't sure if there were changes between 0.9 and 0.10 and hope we can answer those TODOs in the PR conversation

**Changes**
- Created basics.rs for Bevy v0.10 based on basics.rs for Bevy v0.9 and updated all examples so they compile with Bevy v0.10.1
    - `esc_to_menu` differs from the relevant example implementation given in `start_game` in the [Bevy v0.10 announcement](https://bevyengine.org/news/bevy-0-10/#run-conditions). I couldn't find an `Interaction::Pressed` in documentation and rust-analyzer did not recognize it either. I found [an example](https://github.com/bevyengine/bevy/blob/44a365d5403dbdb41862f169c6451457fba1ec98/examples/input/mouse_grab.rs#L26-L29) using `Res<Input<KeyCode>>` from the repo which is where I got my implementation for checking escape key press from.
- Updated documentation in states.md to reflect changes from v0.9 to 0.10
    -  Removed state stack section because states are [no longer stack based](https://bevyengine.org/news/bevy-0-10/#simpler-states)
    - Example references are now to v0.10 code
    - Added TODOs in sections where I need other's input