### PR TITLE
Update system-sets.md to Bevy 0.10.

### DIFF
--- a/src/code/src/basics.rs
+++ b/src/code/src/basics.rs
@@ -1702,52 +1702,6 @@ fn main() {
 }
 
 #[allow(dead_code)]
-mod app9 {
-use bevy::prelude::*;
-
-    fn server_session() {}
-    fn server_updates() {}
-    fn keyboard_input() {}
-    fn gamepad_input() {}
-    fn session_ui() {}
-    fn player_movement() {}
-    fn smoke_particles() {}
-
-// ANCHOR: systemset-labels
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-
-        // group our input handling systems into a set
-        .add_system_set(
-            SystemSet::new()
-                .label("input")
-                .with_system(keyboard_input)
-                .with_system(gamepad_input)
-        )
-
-        // our "net" systems should run before "input"
-        .add_system_set(
-            SystemSet::new()
-                .label("net")
-                .before("input")
-                // individual systems can still have
-                // their own labels (and ordering)
-                .with_system(server_session.label("session"))
-                .with_system(server_updates.after("session"))
-        )
-
-        // some ungrouped systems
-        .add_system(player_movement.after("input"))
-        .add_system(session_ui.after("session"))
-        .add_system(smoke_particles)
-
-        .run();
-}
-// ANCHOR_END: systemset-labels
-}
-
-#[allow(dead_code)]
 mod app10 {
 use bevy::prelude::*;
 

--- a/src/code010/src/lib.rs
+++ b/src/code010/src/lib.rs
@@ -24,6 +24,7 @@ mod d3 {
 }
 mod programming {
     mod intro_code;
+    mod system_sets;
 }
 mod patterns {
 }

--- a/src/code010/src/programming/system_sets.rs
+++ b/src/code010/src/programming/system_sets.rs
@@ -1,0 +1,62 @@
+use bevy::prelude::*;
+
+// ANCHOR: define
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+enum MyGameLoop {
+    HandleInput,
+    UpdateCharacters,
+    ShowResults,
+}
+// ANCHOR_END: define
+
+fn finish_update_system() {}
+
+// ANCHOR: configure
+fn main() {
+    App::new()
+        .configure_set(MyGameLoop::HandleInput.before(MyGameLoop::UpdateCharacters))
+        .configure_set(MyGameLoop::ShowResults.after(finish_update_system))
+        // ... finish building the app ...
+        .run();
+}
+// ANCHOR_END: configure
+
+mod add_systems {
+
+use bevy::prelude::*;
+
+use super::MyGameLoop;
+
+fn add_input_to_characters() {}
+fn handle_jump_button() {}
+fn particle_effect() {}
+
+// ANCHOR: add-systems
+fn main() {
+    App::new()
+        .add_systems(
+            (add_input_to_characters, handle_jump_button)
+                .in_set(MyGameLoop::HandleInput))
+        .add_system(particle_effect.in_set(MyGameLoop::ShowResults))
+        // ... finish building the app ...
+        .run();
+}
+// ANCHOR_END: add-systems
+}
+
+mod nested {
+
+use bevy::prelude::*;
+
+use super::MyGameLoop;
+
+// ANCHOR: nested
+fn main() {
+    App::new()
+        .configure_set(MyGameLoop::ShowResults
+            .in_set(MyGameLoop::UpdateCharacters))
+        // ... finish building the app ...
+        .run();
+}
+// ANCHOR_END: nested
+}

--- a/src/programming/system-sets.md
+++ b/src/programming/system-sets.md
@@ -1,11 +1,32 @@
-{{#include ../include/header09.md}}
+{{#include ../include/header010.md}}
 
 # System Sets
 
-System Sets allow you to easily apply common properties to multiple systems,
-for purposes such as [labeling][cb::label], [ordering][cb::system-order],
-[run criteria][cb::runcriteria], and [states][cb::state].
+System sets allow you to easily apply [ordering][cb::system-order] to a
+collection of systems (even systems that have not been added yet). Ordering
+systems relative to a system set applies that ordering to all systems in the
+set.
+
+First, define system sets:
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:systemset-labels}}
+{{#include ../code010/src/programming/system_sets.rs:define}}
+```
+
+Then, configure the system sets with ordering:
+
+```rust,no_run,noplayground
+{{#include ../code010/src/programming/system_sets.rs:configure}}
+```
+
+And finally, assign systems to the system set:
+
+```rust,no_run,noplayground
+{{#include ../code010/src/programming/system_sets.rs:add-systems}}
+```
+
+System sets can also be "nested":
+
+```rust,no_run,noplayground
+{{#include ../code010/src/programming/system_sets.rs:nested}}
 ```


### PR DESCRIPTION
This basically comes from [this Bevy announcement](https://bevyengine.org/news/bevy-0-10/).

System sets are now pretty much just for defining ordering. There are a couple other functions that are not mentioned here like run_if, but this just seems like a feature on any systems in Bevy 0.10 so it might be redundant to mention that here.