### PR TITLE
Update Exclusive Systems to Bevy 0.10.

### DIFF
--- a/src/code/src/basics.rs
+++ b/src/code/src/basics.rs
@@ -2108,38 +2108,6 @@ fn main() {
 }
 
 #[allow(dead_code)]
-mod app17 {
-use super::*;
-
-fn some_more_things(world: &mut World) {}
-
-// ANCHOR: exclusive-fn
-fn do_crazy_things(world: &mut World) {
-    // we can do anything with any data in the Bevy ECS here!
-}
-// ANCHOR_END: exclusive-fn
-
-// ANCHOR: exclusive-app
-fn main() {
-    App::new()
-        .add_plugins(DefaultPlugins)
-
-        // this will run at the start of CoreStage::Update (the default stage)
-        .add_system(do_crazy_things)
-
-        // this will run at the end of CoreStage::PostUpdate
-        .add_system_to_stage(
-            CoreStage::PostUpdate,
-            some_more_things
-                .at_end()
-        )
-
-        .run();
-}
-// ANCHOR_END: exclusive-app
-}
-
-#[allow(dead_code)]
 mod app18 {
 use super::*;
 // ANCHOR: globaltransform

--- a/src/code010/src/lib.rs
+++ b/src/code010/src/lib.rs
@@ -23,6 +23,7 @@ mod d2 {
 mod d3 {
 }
 mod programming {
+    mod exclusive;
     mod intro_code;
 }
 mod patterns {

--- a/src/code010/src/programming/exclusive.rs
+++ b/src/code010/src/programming/exclusive.rs
@@ -1,0 +1,31 @@
+use bevy::prelude::*;
+
+fn system_a() {}
+fn system_b() {}
+
+// ANCHOR: exclusive-fn
+fn do_crazy_things(world: &mut World) {
+    // we can do anything with any data in the Bevy ECS here!
+}
+// ANCHOR_END: exclusive-fn
+
+// ANCHOR: command-flush
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        
+        .add_systems(
+            (
+                // This system produces some commands
+                system_a,
+                // This will apply the queued commands from system_a
+                apply_system_buffers,
+                // This system will have access to the results of
+                // system_a's commands
+                system_b,
+            ).chain() // Ensure the order of these systems is maintained.
+        )
+
+        .run();
+}
+// ANCHOR_END: command-flush

--- a/src/programming/exclusive.md
+++ b/src/programming/exclusive.md
@@ -1,4 +1,4 @@
-{{#include ../include/header09.md}}
+{{#include ../include/header010.md}}
 
 # Exclusive Systems
 
@@ -25,22 +25,17 @@ See the [direct World access page][cb::world] to learn more about how to do
 such things.
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:exclusive-fn}}
+{{#include ../code010/src/programming/exclusive.rs:exclusive-fn}}
 ```
 
 You need to add exclusive systems to the [App][cb::app], just like
-regular systems, but you must call `.exclusive_system()` on them.
+regular systems, and exclusive systems can be ordered [just like regular
+systems][cb::system-order].
 
-They cannot be ordered in-between regular parallel systems. Exclusive systems
-always run at one of the following places:
- - `.at_start()`: at the beginning of a [stage][cb::stage]
- - `.at_end()`: at the end of a [stage][cb::stage],
-   after [commands][cb::commands] from regular systems have been applied
- - `.before_commands()`: after all the regular systems in a [stage][cb::stage],
-   but before [commands][cb::commands] are applied
-
-(if you don't specify anything, the default is assumed `.at_start()`)
+One notable, already-provided exclusive system is `apply_system_buffers`. It
+performs a command flush which applies all queued-up [`Commands`][cb::commands]
+added in systems since the last command flush.
 
 ```rust,no_run,noplayground
-{{#include ../code/src/basics.rs:exclusive-app}}
+{{#include ../code010/src/programming/exclusive.rs:command-flush}}
 ```


### PR DESCRIPTION
Most of the page is the same, although several of the limitations are gone. I also added reference to `apply_system_buffers`.

This pretty much entirely comes from [the Bevy 0.10 announcement](https://bevyengine.org/news/bevy-0-10/#directly-schedule-exclusive-systems).