### PR TITLE
Make image references relative to src

### DIFF
--- a/src/3d/camera.md
+++ b/src/3d/camera.md
@@ -78,7 +78,7 @@ For reference, a good neutral value is 45° (narrower, Bevy default) or 60°
 {{#include ../code012/src/d3/camera.rs:fov}}
 ```
 
-![Side-by-side comparison of different FOV values.](/img/camera-3d-fov.png)
+![Side-by-side comparison of different FOV values.](../img/camera-3d-fov.png)
 
 In the above image, we are halving/doubling the FOV and doubling/halving
 how far away the camera is positioned, to compensate. Note how you can see
@@ -101,14 +101,14 @@ If the camera does not move, decreasing the FOV makes everything appear closer
 and increasing it makes everything appear more distant:
 
 ![Side-by-side comparison of a "zoomed in" (small FOV) and a "zoomed out" (large FOV)
-3D scene](/img/camera-3d-fov-zoom.png)
+3D scene](../img/camera-3d-fov-zoom.png)
 
 Contrast this with moving the camera itself (using the
 [transform][cb::transform]) closer or further away, while keeping the FOV the
 same:
 
 ![Side-by-side comparison of a camera positioned nearer to vs. further away from a
-3D scene](/img/camera-3d-position.png)
+3D scene](../img/camera-3d-position.png)
 
 In some applications (such as 3D editors), moving the camera might be preferable,
 instead of changing the FOV.
@@ -135,7 +135,7 @@ to handle window size / resolution.
 {{#include ../code012/src/d3/camera.rs:ortho}}
 ```
 
-![Visualization of a 3D scene with orthographic projection](/img/camera-3d-orthographic.png)
+![Visualization of a 3D scene with orthographic projection](../img/camera-3d-orthographic.png)
 
 #### Zooming
 
@@ -146,4 +146,4 @@ how much of the scene is visible.
 {{#include ../code012/src/d3/camera.rs:orthographic-zoom}}
 ```
 
-![Side-by-side comparison of different orthographic projection scale in 3D](/img/camera-3d-orthographic-zoom.png)
+![Side-by-side comparison of different orthographic projection scale in 3D](../img/camera-3d-orthographic-zoom.png)

--- a/src/fundamentals/coords.md
+++ b/src/fundamentals/coords.md
@@ -26,7 +26,7 @@ hand to visualize the 3 axes: thumb=X, index=Y, middle=Z.
 It is the same as Godot, Maya, and OpenGL. Compared to Unity, the Z axis
 is inverted.
 
-![Chart comparing coordinate system orientation in different game engines and 3D software](/img/handedness.png)
+![Chart comparing coordinate system orientation in different game engines and 3D software](../img/handedness.png)
 
 (graphic modifed and used with permission; original by [@FreyaHolmer](https://twitter.com/FreyaHolmer))
 

--- a/src/gpu/intro.md
+++ b/src/gpu/intro.md
@@ -37,7 +37,7 @@ frame, store it in resources. Dynamic data that could change every frame
 should be copied into the render world in the Extract stage, and typically
 stored using entities and components.
 
-![Diagram of pipelined rendering timings in app-bound and render-bound cases](/img/pipelined-rendering.png)
+![Diagram of pipelined rendering timings in app-bound and render-bound cases](../img/pipelined-rendering.png)
 
 ## Core Architecture
 

--- a/src/gpu/stages.md
+++ b/src/gpu/stages.md
@@ -14,7 +14,7 @@ explains the intended behavior, which will land in a future Bevy version. You
 have to understand it, because any custom rendering code you write will have to
 work with it in mind.
 
-![Diagram of pipelined rendering timings in app-bound and render-bound cases](/img/pipelined-rendering.png)
+![Diagram of pipelined rendering timings in app-bound and render-bound cases](../img/pipelined-rendering.png)
 
 Every frame, [Extract](#extract) serves as the synchronization point.
 

--- a/src/graphics/bloom.md
+++ b/src/graphics/bloom.md
@@ -91,8 +91,8 @@ BloomSettings {
 
 Here is an example of Bloom in 3D:
 
-![The Bloom effect on street lamps.](/img/bloom_3d.png)
+![The Bloom effect on street lamps.](../img/bloom_3d.png)
 
 And here is a 2D example:
 
-![The Bloom effect on a simple hexagon.](/img/bloom_2d.png)
+![The Bloom effect on a simple hexagon.](../img/bloom_2d.png)

--- a/src/graphics/hdr-tonemap.md
+++ b/src/graphics/hdr-tonemap.md
@@ -130,4 +130,4 @@ Pay attention to the quality/smoothness of the green color gradient on the
 ground plane. In games with photorealistic graphics, similar situations can
 arise in the sky, in dark rooms, or lights glowing with a bloom effect.
 
-![Visual comparison of a scene simple cube on a flat green plane, with dithering disabled/enabled.](/img/dithering.png)
+![Visual comparison of a scene simple cube on a flat green plane, with dithering disabled/enabled.](../img/dithering.png)

--- a/src/setup/perf.md
+++ b/src/setup/perf.md
@@ -171,7 +171,7 @@ framerate, or it might not be. Here is a diagram to visualize what happens:
 
 ![Timeline comparing pipelined and non-pipelined rendering. In the pipelined
 case, one additional frame is displayed before the effects of the mouse click
-can be seen on-screen.](/img/pipelined-latency.png)
+can be seen on-screen.](../img/pipelined-latency.png)
 
 The actual mouse click happens in-between frames. In both cases, frame #4 is
 when the input is detected by Bevy. In the pipelined case, rendering


### PR DESCRIPTION
This allow for creation of EPUB document using mdbook-epub. This is not a content change, just a minor tweak to file paths for embedded images. The output looks the same for the HTML rendering.