### PR TITLE
Fix mouse.rs bug

### DIFF
--- a/src/code011/src/input/mouse.rs
+++ b/src/code011/src/input/mouse.rs
@@ -63,7 +63,7 @@ use bevy::input::mouse::MouseMotion;
 fn mouse_motion(
     mut motion_evr: EventReader<MouseMotion>,
 ) {
-    for ev in motion_evr.iter() {
+    for ev in motion_evr.read() {
         println!("Mouse moved: X: {} px, Y: {} px", ev.delta.x, ev.delta.y);
     }
 }


### PR DESCRIPTION
Fixes `no method named iter found for struct bevy::prelude::EventReader in the current scope` error when trying to read unread inputs from the EventReader by replacing `iter` with `read`