### PR TITLE
fix(docs): correct typos in various markdown and Rust files

### DIFF
--- a/src/3d/gltf.md
+++ b/src/3d/gltf.md
@@ -215,9 +215,9 @@ The advantage is that you can get handles to your sub-assets immediately,
 even if your GLTF file hasn't loaded yet.
 
 The disadvantage is that it is more error-prone. If you specify a sub-asset
-that doesn't actually exist in the file, or mis-type the label, or use the
+that doesn't actually exist in the file, or mistype the label, or use the
 wrong label, it will just silently not work. Also, currently only using a
-numerial index is supported. You cannot address sub-assets by name.
+numerical index is supported. You cannot address sub-assets by name.
 
 ```rust,no_run,noplayground
 {{#include ../code/src/basics.rs:gltf-assetpath}}

--- a/src/code012/src/setup/perf.rs
+++ b/src/code012/src/setup/perf.rs
@@ -90,7 +90,7 @@ use bevy::pbr::ClusterConfig;
 
 commands.spawn((
     Camera3dBundle {
-        // ... your 3D camera configruation
+        // ... your 3D camera configuration
         ..Default::default()
     },
     ClusterConfig::FixedZ {
@@ -108,7 +108,7 @@ commands.spawn((
 // ANCHOR: cluster-single
 commands.spawn((
     Camera3dBundle {
-        // ... your 3D camera configruation
+        // ... your 3D camera configuration
         ..Default::default()
     },
     ClusterConfig::Single,

--- a/src/code013/src/setup/perf.rs
+++ b/src/code013/src/setup/perf.rs
@@ -90,7 +90,7 @@ use bevy::pbr::ClusterConfig;
 
 commands.spawn((
     Camera3dBundle {
-        // ... your 3D camera configruation
+        // ... your 3D camera configuration
         ..Default::default()
     },
     ClusterConfig::FixedZ {
@@ -108,7 +108,7 @@ commands.spawn((
 // ANCHOR: cluster-single
 commands.spawn((
     Camera3dBundle {
-        // ... your 3D camera configruation
+        // ... your 3D camera configuration
         ..Default::default()
     },
     ClusterConfig::Single,

--- a/src/fundamentals/coords.md
+++ b/src/fundamentals/coords.md
@@ -28,7 +28,7 @@ is inverted.
 
 ![Chart comparing coordinate system orientation in different game engines and 3D software](../img/handedness.png)
 
-(graphic modifed and used with permission; original by [@FreyaHolmer](https://twitter.com/FreyaHolmer))
+(graphic modified and used with permission; original by [@FreyaHolmer](https://twitter.com/FreyaHolmer))
 
 ## UI
 

--- a/src/fundamentals/fixed-timestep.md
+++ b/src/fundamentals/fixed-timestep.md
@@ -82,7 +82,7 @@ of your gameplay/physics simulation, but you also want it to look smooth on-scre
 For input handling, you want it to be responsive and handled every frame, but
 you also have game mechanics that need to respond to it.
 
-The most elegant solution to both of these problems is to handle synchonization
+The most elegant solution to both of these problems is to handle synchronization
 yourself using custom types.
 
 #### Movement

--- a/src/fundamentals/hierarchy.md
+++ b/src/fundamentals/hierarchy.md
@@ -90,7 +90,7 @@ your entities have all the necessary components.
 If you despawn an entity that has a parent, Bevy does not remove it from the
 parent's [`Children`][bevy::Children].
 
-If you then query for that parent entity's children, you will get an invaild
+If you then query for that parent entity's children, you will get an invalid
 entity, and any attempt to manipulate it will likely lead to this error:
 
 ```

--- a/src/gpu/intro.md
+++ b/src/gpu/intro.md
@@ -55,7 +55,7 @@ with regard to one another.
 
 ## Layers of Abstraction
 
-The Bevy rendering framework can accomodate you working at various different
+The Bevy rendering framework can accommodate you working at various different
 levels of abstraction, depending on how much you want to integrate with the
 Bevy ecosystem and built-in features, vs. have more direct control over the GPU.
 

--- a/src/graphics/hdr-tonemap.md
+++ b/src/graphics/hdr-tonemap.md
@@ -48,7 +48,7 @@ Web/WASM, crashing at runtime. Disable MSAA if you experience any such issues.
 ## Tonemapping
 
 Tonemapping is the step of the rendering process where the colors of pixels are
-converted from their in-engine intermediate repesentation into the final values
+converted from their in-engine intermediate representation into the final values
 as they should be displayed on-screen.
 
 This is very important with HDR applications, as in that case the image can

--- a/src/overview.md
+++ b/src/overview.md
@@ -24,7 +24,7 @@ The book has the following general chapters:
 
  - [Bevy Setup Tips][chapter::setup]: project setup advice, recommendations for tools and plugins
  - [Common Pitfalls][chapter::pitfalls]: solutions for common issues encountered by the community
- - [Bevy on Different Platforms][chapter::platforms]: information about working with specific plaforms / OSs
+ - [Bevy on Different Platforms][chapter::platforms]: information about working with specific platforms / OSs
 
 <!-- - [Appendix: General Concepts][chapter::concepts]: various general gamedev knowledge, not specific to Bevy -->
 

--- a/src/platforms/macos.md
+++ b/src/platforms/macos.md
@@ -33,7 +33,7 @@ Some keyboard keys have a somewhat-unintuitive mapping:
 
 Other key codes have their intuitive names.
 
-### Window Management Apps Compatability
+### Window Management Apps Compatibility
 
 Bevy apps can encounter performance issues (such as lag when dragging the window
 around the screen) when window management apps like "Magnet" are used. This is a

--- a/src/platforms/wasm/webpage.md
+++ b/src/platforms/wasm/webpage.md
@@ -44,7 +44,7 @@ The final list of files for a minimal website will look something like this:
 assets/ index.html mygame.js mygame_bg.wasm
 ```
 
-In a more compex website, you might want to have the game files be in a
+In a more complex website, you might want to have the game files be in a
 subdirectory somewhere, and load them from a HTML file elsewhere.
 
 For the HTML file, you can use this as a starting point:

--- a/src/programming/exclusive.md
+++ b/src/programming/exclusive.md
@@ -63,7 +63,7 @@ after you are done! That is when the deferred operations queued via
 
 Exclusive systems, by definition, limit parallelism and multi-threading, as
 nothing else can access the same ECS World while they run. The whole schedule
-needs to come to a stop, to accomodate the exclusive system. This can easily
+needs to come to a stop, to accommodate the exclusive system. This can easily
 introduce a performance bottleneck.
 
 Generally speaking, you should avoid using exclusive systems, unless you need

--- a/src/programming/intro-code.md
+++ b/src/programming/intro-code.md
@@ -53,7 +53,7 @@ different and unpredictable order relative to one another, unless you add
 [Exclusive][cb::exclusive] systems provide you with a way to get [full direct
 access][cb::world] to the ECS [`World`][cb::World]. They cannot run in parallel
 with other systems, because they can access anything and do anything. Sometimes,
-you might need this additonal power.
+you might need this additional power.
 
 ```rust,no_run,noplayground
 {{#include ../code013/src/programming/intro_code.rs:exclusive}}

--- a/src/setup/cross/linux-windows.md
+++ b/src/setup/cross/linux-windows.md
@@ -54,7 +54,7 @@ You don't need any files from Microsoft.
 ## First-Time Setup (MSVC)
 
 The MSVC toolchain is the native Microsoft way to target Windows. It is what
-the Rust community usually recommends for targetting the Windows platform. It
+the Rust community usually recommends for targeting the Windows platform. It
 may provide better compatibility with Windows DLLs / libraries and tooling.
 
 Even though it is meant to be used on Windows, you can actually set it up

--- a/src/setup/cross/macos-windows.md
+++ b/src/setup/cross/macos-windows.md
@@ -54,7 +54,7 @@ You don't need any files from Microsoft.
 ## First-Time Setup (MSVC)
 
 The MSVC toolchain is the native Microsoft way to target Windows. It is what
-the Rust community usually recommends for targetting the Windows platform. It
+the Rust community usually recommends for targeting the Windows platform. It
 may provide better compatibility with Windows DLLs / libraries and tooling.
 
 Even though it is meant to be used on Windows, you can actually set it up and
@@ -134,7 +134,7 @@ brew install cmake
 Now, we are ready to compile LLD from the LLVM project:
 
 Note: the `--depth=1` option to `git clone` allows us to save a lot of disk
-space and download bandwidth, because the LLVM respository is *huge*.
+space and download bandwidth, because the LLVM repository is *huge*.
 
 ```sh
 git clone --depth=1 https://github.com/llvm/llvm-project

--- a/src/setup/perf.md
+++ b/src/setup/perf.md
@@ -11,7 +11,7 @@ these settings, but if your game does not perform well with Bevy's default
 configuration, this page will show you some things you can try to change, to see
 if they help your project.
 
-Bevy's default configruation is designed with *scalability* in mind. That is, so
+Bevy's default configuration is designed with *scalability* in mind. That is, so
 that you don't have to worry too much about performance, as you add more
 features and complexity to your project. Bevy will automatically take care to
 distribute the workload as to make good use of the available hardware (GPU, CPU

--- a/src/window/clear-color.md
+++ b/src/window/clear-color.md
@@ -9,7 +9,7 @@ Relevant official examples:
 
 Use the [`ClearColor`] [resource][cb::res] to choose the default background
 color. This color will be used as the default for all [cameras][cb::camera],
-unless overriden.
+unless overridden.
 
 Note that the window will be black if no cameras exist. You must spawn at
 least one camera.


### PR DESCRIPTION
Corrected typos in various markdown and Rust files using [typoscli](https://github.com/crate-ci/typos). Detailed list of changes in the commit message.