### PR TITLE
Fix improperly closed script tag in cursor2world.md

### DIFF
--- a/src/cookbook/cursor2world.md
+++ b/src/cookbook/cursor2world.md
@@ -82,4 +82,4 @@ For some examples:
 
 </details>
 
-<script type="module" src="/loadwasm.js"/>
+<script type="module" src="/loadwasm.js"></script>


### PR DESCRIPTION
The script tag was at the end of the file, and it was closed like `<script/>` instead of `<script></script>` which made the generated print.html file stop at the cursor2world file.