### PR TITLE
Adds Necessary Events Update System Function Handler To Docs

### DIFF
--- a/src/code014/src/programming/events.rs
+++ b/src/code014/src/programming/events.rs
@@ -32,5 +32,7 @@ fn main() {
 // ANCHOR: events-appbuilder
 app.add_event::<LevelUpEvent>();
 // ANCHOR_END: events-appbuilder
+    // ANCHOR: events-update-system
     app.add_systems(Update, (player_level_up, debug_levelups));
+    // ANCHOR_END: events-update-system
 }

--- a/src/programming/events.md
+++ b/src/programming/events.md
@@ -26,10 +26,11 @@ the same events from multiple [systems][cb::system].
 {{#include ../code014/src/programming/events.rs:events}}
 ```
 
-You need to register your custom event types via the [app builder][cb::app]:
+You need to register your custom event types and update systems via the [app builder][cb::app]:
 
 ```rust,no_run,noplayground
 {{#include ../code014/src/programming/events.rs:events-appbuilder}}
+{{#include ../code014/src/programming/events.rs:events-update-system}}
 ```
 
 ## Usage Advice


### PR DESCRIPTION

Hi!

This was confusing to me when I first read it and it said all I had to do was register the events types...

Makes sense that you would need to register these functions, but I think explicitly putting it in the docs this way reduces the change for confusion and misinterpretation.  🤓 👍 