### PR TITLE
minor fixes: one shot item handler example name and version bump mouse grab example

### DIFF
--- a/src/code014/src/programming/one_shot_systems.rs
+++ b/src/code014/src/programming/one_shot_systems.rs
@@ -18,7 +18,7 @@ enum MyMagicEvent {
 }
 
 // ANCHOR: example
-fn item_handler_health(
+fn item_handler_health_potion(
     mut q_player: Query<&mut Health, With<Player>>,
 ) {
     let mut health = q_player.single_mut();
@@ -46,7 +46,7 @@ impl FromWorld for MyItemSystems {
 
         my_item_systems.0.insert(
             "health".into(),
-            world.register_system(item_handler_health)
+            world.register_system(item_handler_health_potion)
         );
         my_item_systems.0.insert(
             "magic".into(),
@@ -64,7 +64,7 @@ fn register_item_handler_systems(world: &mut World) {
 
     my_item_systems.0.insert(
         "health".into(),
-        world.register_system(item_handler_health)
+        world.register_system(item_handler_health_potion)
     );
     my_item_systems.0.insert(
         "magic".into(),
@@ -115,7 +115,7 @@ fn my_plugin(app: &mut App) {
 
     my_item_systems.0.insert(
         "health".into(),
-        app.register_system(item_handler_health)
+        app.register_system(item_handler_health_potion)
     );
     my_item_systems.0.insert(
         "magic".into(),

--- a/src/window/mouse-grab.md
+++ b/src/window/mouse-grab.md
@@ -1,4 +1,4 @@
-{{#include ../include/header013.md}}
+{{#include ../include/header014.md}}
 
 # Grabbing the Mouse
 
@@ -18,13 +18,13 @@ There are two variations on this behavior ([`CursorGrabMode`]):
 To grab the cursor:
 
 ```rust,no_run,noplayground
-{{#include ../code013/src/window/mouse_grab.rs:grab}}
+{{#include ../code014/src/window/mouse_grab.rs:grab}}
 ```
 
 To release the cursor:
 
 ```rust,no_run,noplayground
-{{#include ../code013/src/window/mouse_grab.rs:ungrab}}
+{{#include ../code014/src/window/mouse_grab.rs:ungrab}}
 ```
 
 You should grab the cursor during active gameplay and release it when
@@ -43,9 +43,9 @@ Windows does not natively support `Locked` mode. Bevy will fallback to `Confined
 You could emulate the locked behavior by re-centering the cursor every frame:
 
 ```rust,no_run,noplayground
-{{#include ../code013/src/window/mouse_grab.rs:recenter}}
+{{#include ../code014/src/window/mouse_grab.rs:recenter}}
 ```
 
 ```rust,no_run,noplayground
-{{#include ../code013/src/window/mouse_grab.rs:recenter-app}}
+{{#include ../code014/src/window/mouse_grab.rs:recenter-app}}
 ```


### PR DESCRIPTION
These are some very minor changes as you mention in your contribution policy:
- The one shot system example `item_handler_health` was missing the `_potion` suffix
- The mouse grab example is up to date and works in 0.14