### PR TITLE
Fix typo in transforms sample code

### DIFF
--- a/src/code012/src/fundamentals/transforms.rs
+++ b/src/code012/src/fundamentals/transforms.rs
@@ -30,7 +30,7 @@ let xf_rot2d = Transform::from_rotation(Quat::from_rotation_z((30.0_f32).to_radi
 // 3D rotations can be complicated; explore the methods available on `Quat`
 
 // Simple 3D rotation by Euler-angles (X, Y, Z)
-let xf_rot2d = Transform::from_rotation(Quat::from_euler(
+let xf_rot3d = Transform::from_rotation(Quat::from_euler(
     EulerRot::XYZ,
     (20.0_f32).to_radians(),
     (10.0_f32).to_radians(),


### PR DESCRIPTION
Hi,
I noticed a typo in the sample code. The second Transform is a 3D transform, not a 2D one, and it shadows the previously declared variable. This appears to be a mistake.
