### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Ida Iyes"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Unofficial Bevy Cheat Book"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10